### PR TITLE
Specify install directory with environment variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,13 @@
 # Installation script for the fedra-package   #
 # 14.11.03                                    #
 
-[[ -z "${FEDRA_INSTALL_DIR}" ]] && installdir=`pwd` || installdir="${FEDRA_INSTALL_DIR}"
-
+if [[ -z "${FEDRA_INSTALL_DIR}" ]]; then
+ installdir=`pwd`
+else
+ installdir="${FEDRA_INSTALL_DIR}"
+ scriptdir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ cp ${scriptdir}/* ${installdir}
+fi
 if [[ ${installdir##*/} == "src" ]] ; then
  installdir=`cd ..; pwd`
 fi

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [[ -z "${FEDRA_INSTALL_DIR}" ]]; then
 else
  installdir="${FEDRA_INSTALL_DIR}"
  scriptdir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
- cp ${scriptdir}/* ${installdir}
+ cp -r ${scriptdir}/* ${installdir}
 fi
 if [[ ${installdir##*/} == "src" ]] ; then
  installdir=`cd ..; pwd`

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 # Installation script for the fedra-package   #
 # 14.11.03                                    #
 
-installdir=`pwd`
+[[ -z "${FEDRA_INSTALL_DIR}" ]] && installdir=`pwd` || installdir="${FEDRA_INSTALL_DIR}"
+
 if [[ ${installdir##*/} == "src" ]] ; then
  installdir=`cd ..; pwd`
 fi


### PR DESCRIPTION
The install directory can now be set in the environment variable `FEDRA_INSTALL_DIR`. If the variable is not set, the install script defaults to the old behaviour (installs in `PWD`).
This helps integration in aliBuild.