### PR TITLE
Linking and tracking in cells

### DIFF
--- a/src/appl/emrec/emlink.cpp
+++ b/src/appl/emrec/emlink.cpp
@@ -21,6 +21,8 @@ void print_help_message()
   cout<< "\t\t  -new  - new linking (renewed 06-04-11)\n";
   cout<< "\t\t  -view - check view overlaps\n";
   cout<< "\t\t  DEBUG - verbosity level: 0-print nothing, 1-errors only, 2-normal, 3-print all messages\n";
+  cout<< "\t\t  -ix   - x cell bin\n";
+  cout<< "\t\t  -iy   - y cell bin\n";
   cout<< "\nExample: \n";
   cout<< "\t  emlink -id=4554.10.1.0 -o=/scratch/BRICKS \n";
   cout<< "\n If the data location directory is not explicitly defined\n";
@@ -92,6 +94,7 @@ int main(int argc, char* argv[])
   bool      do_check_view   = false;
   Int_t     brick=0, plate=0, major=0, minor=0;
   Int_t     npre=0,  nfull=0;
+  Int_t	    ix = -1, iy = -1; //cell numbers
   Int_t     correct_ang=0;
 
   for(int i=1; i<argc; i++ ) {
@@ -139,6 +142,14 @@ int main(int argc, char* argv[])
       {
 	if(strlen(key)>3)	gEDBDEBUGLEVEL = atoi(key+3);
       }
+    else if(!strncmp(key,"-ix=",4))
+      {
+	if(strlen(key)>4)	ix = atoi(key+4);
+      }
+    else if(!strncmp(key,"-iy=",4))
+      {
+	if(strlen(key)>4)	iy = atoi(key+4);
+      }
   }
 
   if(!(do_id||do_set))   { print_help_message(); return 0; }
@@ -164,7 +175,8 @@ int main(int argc, char* argv[])
       EdbScanSet *ss = sproc.ReadScanSet(id0);
       if(ss) {
         EdbPlateP *plate = ss->GetPlate(id.ePlate);
-        if(plate) sproc.LinkRunTest(id, *plate, cenv);
+        printf("test0, %d, %d",ix,iy);
+        if(plate) sproc.LinkRunTest(id, *plate, cenv, ix, iy);
      }
     }
     else if(do_check_view) sproc.CheckViewOverlaps(id, cenv);
@@ -179,7 +191,7 @@ int main(int argc, char* argv[])
     EdbScanSet *ss = sproc.ReadScanSet(id);
     if(ss) {
       if(do_new) {
-        sproc.LinkSetNewTest(*ss, cenv);
+        sproc.LinkSetNewTest(*ss, cenv, ix, iy);
         sproc.MakeLinkSetSummary(id, reportfileformat);
       }
       else  if(npre+nfull>0)  sproc.LinkSet(*ss, npre, nfull, correct_ang);

--- a/src/appl/emrec/emtra.cpp
+++ b/src/appl/emrec/emtra.cpp
@@ -84,6 +84,7 @@ int main(int argc, char* argv[])
   bool      do_VSB              = false;
   Int_t     pred_plate  = 0, to_plate=0;
   Int_t     brick=0, plate=0, major=0, minor=0;
+  Int_t	    ix = -1, iy = -1; //cell numbers
 
   for(int i=1; i<argc; i++ ) {
     char *key  = argv[i];
@@ -123,6 +124,14 @@ int main(int argc, char* argv[])
       {
 	if(strlen(key)>3)	gEDBDEBUGLEVEL = atoi(key+3);
       }
+    else if(!strncmp(key,"-ix=",4))
+      {
+	if(strlen(key)>4)	ix = atoi(key+4);
+      }
+    else if(!strncmp(key,"-iy=",4))
+      {
+	if(strlen(key)>4)	iy = atoi(key+4);
+      }
   }
 
   if(!do_set)   { print_help_message(); return 0; }
@@ -146,7 +155,7 @@ int main(int argc, char* argv[])
       {
           EdbScanTracking est;
           est.eSproc=&sproc;
-          est.TrackSetBT(id,cenv);
+          est.TrackSetBT(id,cenv,ix,iy);
       }
       else if(do_make_erase_file){
         MakeEraseFiles(id, cenv);

--- a/src/libScan/EdbScanProc.cxx
+++ b/src/libScan/EdbScanProc.cxx
@@ -3135,15 +3135,40 @@ bool EdbScanProc::InitRunAccessNew(EdbRunAccess &r, EdbID id, EdbPlateP &plate, 
 }
 
 //--------------------------------------------------------------------
-void EdbScanProc::LinkRunTest( EdbID id, EdbPlateP &plate, TEnv &cenv)
+void EdbScanProc::LinkRunTest( EdbID id, EdbPlateP &plate, TEnv &cenv, Int_t ix, Int_t iy)
 {
+  //which cell are we looking for? -1, no cell at all.
+
   EdbRunAccess r;
   r.eInvertSides=cenv.GetValue("fedra.link.read.InvertSides"      , 0);
   r.eHeaderCut = cenv.GetValue("fedra.link.read.HeaderCut"      , "1");
+
+  if (ix >= 0 && iy >= 0){
+
+    int ncellsX = cenv.GetValue("fedra.link.map.NX"      , 19);
+    int ncellsY = cenv.GetValue("fedra.link.map.NY"      , 19);
+
+    float xmin = cenv.GetValue("fedra.link.map.xmin"      , 0.);
+    float xmax = cenv.GetValue("fedra.link.map.xmax"      , 190000.);
+    float ymin = cenv.GetValue("fedra.link.map.ymin"      , 0.);
+    float ymax = cenv.GetValue("fedra.link.map.ymax"      , 190000.);
+
+    float overlap_fraction = cenv.GetValue("fedra.link.map.overlapfraction"      , 0.); //how much should they overlap (for each side)
+
+    printf("EdbScanProc::LinkRunTest ** processing cell %d %d\n", ix , iy);
+    EdbCell2 * emulsioncell = new EdbCell2();
+    Log(2,"LinkRunTest","cell layout, %d x cells from %f to %f, %d y cells from %f to %f",ncellsX, xmin, xmax, ncellsY, ymin, ymax );
+    emulsioncell->InitCell(ncellsX,xmin,xmax,ncellsY,ymin,ymax,1); //1 is the maximum number for cells. In this case I use the cells only to map positions
+    //setting header cut manually
+    r.eHeaderCut = Form("TMath::Abs(eXview-%f) < %f && TMath::Abs(eYview-%f) < %f",
+      emulsioncell->X(ix),emulsioncell->Xbin()*(1.+overlap_fraction)/2.,emulsioncell->Y(iy),emulsioncell->Ybin()*(1.+overlap_fraction)/2.);
+  }
+
   r.eHeaderCut.Print();
   r.eAFID           =  cenv.GetValue("fedra.link.AFID"      , 1);
   printf("EdbScanProc::LinkRunTest ** AFID=%d\n", r.eAFID);
   InitRunAccessNew(r,id,plate);
+  
   r.eWeightAlg  =  cenv.GetValue("fedra.link.read.WeightAlg"      , 0  );
   r.AddSegmentCut(1,cenv.GetValue("fedra.link.read.ICUT"      , "-1") );
   r.SetPixelCorrection( cenv.GetValue("fedra.link.PixelCorr"      , "0 1. 1.") );
@@ -3157,6 +3182,7 @@ void EdbScanProc::LinkRunTest( EdbID id, EdbPlateP &plate, TEnv &cenv)
 
   EdbLinking link;
   TString cpfile;
+
   MakeFileName(cpfile,id,"cp.root");
   link.InitOutputFile( cpfile );
 
@@ -3239,13 +3265,13 @@ void EdbScanProc::LinkRunNew( EdbID id, EdbPlateP &plate, TEnv &cenv)
 }
 
 //----------------------------------------------------------------
-void EdbScanProc::LinkSetNewTest(EdbScanSet &sc, TEnv &cenv )
+void EdbScanProc::LinkSetNewTest(EdbScanSet &sc, TEnv &cenv, Int_t ix, Int_t iy)
 {
   if(sc.eIDS.GetSize()<1) return;
   for(int i=0; i<sc.eIDS.GetSize(); i++) {
     EdbID *id = (EdbID *)(sc.eIDS.At(i));        if(!id)    continue;
     EdbPlateP *plate = sc.GetPlate(id->ePlate);  if(!plate) continue;
-    LinkRunTest(*id, *plate, cenv);
+    LinkRunTest(*id, *plate, cenv,ix,iy);
   }
 }
 

--- a/src/libScan/EdbScanProc.h
+++ b/src/libScan/EdbScanProc.h
@@ -107,10 +107,10 @@ public:
   int     LinkSet(EdbScanSet &sc, int npre=3, int nfull=1, int correct_ang=1);
 
   void     GetPatternSide( EdbID id, int side, EdbLayer &la, const char *segcut, int afid, EdbPattern &p);
-  void     LinkRunTest(EdbID id, EdbPlateP &plate, TEnv &cenv);
+  void     LinkRunTest(EdbID id, EdbPlateP &plate, TEnv &cenv, Int_t ix = -1, Int_t iy = -1);
   void     LinkRunNew(EdbID id, EdbPlateP &plate, TEnv &cenv);
   void     LinkSetNew(EdbScanSet &sc, TEnv &cenv);
-  void     LinkSetNewTest(EdbScanSet &sc, TEnv &cenv);
+  void     LinkSetNewTest(EdbScanSet &sc, TEnv &cenv, Int_t ix = -1, Int_t iy = -1);
 
   //void     WriteSetGeom(EdbScanSet &sc);
   //void     ReadSetGeom(EdbScanSet &sc);
@@ -230,6 +230,6 @@ public:
   void    LogPrint(int brick, int level, const char *rout, const char *msgfmt, ...);
   void    Print();
   
-  ClassDef(EdbScanProc,1)  // scanned data processing
+  ClassDef(EdbScanProc,2)  // scanned data processing
 };
 #endif /* ROOT_EdbScanProc */

--- a/src/libScan/EdbScanTracking.h
+++ b/src/libScan/EdbScanTracking.h
@@ -90,10 +90,10 @@ class EdbScanTracking: public TObject {
    virtual ~EdbScanTracking(){}
 
    void  TrackAli(EdbPVRec &ali, TEnv &env);
-   void  TrackSetBT(EdbID id, TEnv &env);
+   void  TrackSetBT(EdbID id, TEnv &env, Int_t ix = -1, Int_t iy = -1);
    void  SaveHist(EdbID idset, EdbTrackAssembler &etra);
  
-   ClassDef(EdbScanTracking,1) // To handle tracking in the scanset
+   ClassDef(EdbScanTracking,2) // To handle tracking in the scanset
 };
 
 


### PR DESCRIPTION
Dear all,

This pull request includes the implementation by myself and Fabio Alicante of base-track and volume-track reconstruction in single cells, instead of the full area.

This implementation allows parallel processing of the single cells separately, for example with the CERN Batch system HTCondor. Also, it improves accuracy by computing different shrinkage and angular correction for the single cells.

Number and size of the cells can be provided as parameters in the link.rootrc and track.rootrc files